### PR TITLE
a태그 hover 시 툴팁 띄우기

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 - [ ] 내용 작성작성
   - 내용 작성작성📝
 
+- closed #
+
 ## 📷 완료된 기능 사진
 <div align="center">
   <img src="">

--- a/components/movie.tsx
+++ b/components/movie.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useRef } from 'react';
 import styles from '@styles/movie.module.css';
 
 interface MovieProps {
@@ -12,14 +13,32 @@ interface MovieProps {
 
 export default function Movie({ title, id, poster_path }: MovieProps) {
   const router = useRouter();
+  const pRef = useRef<HTMLParagraphElement>(null);
+
   const showDetail = () => {
     router.push(`/movies/${id}`);
+  };
+
+  const tooltip = () => {
+    if (pRef.current) pRef.current.style.display = 'block';
+  };
+
+  const hideTooltip = () => {
+    if (pRef.current) pRef.current.style.display = 'none';
   };
 
   return (
     <div className={styles.movie}>
       <img src={poster_path} alt={title} onClick={showDetail} />
-      <Link href={`/movies/${id}`}>{title}</Link>
+      <p ref={pRef}>{title}</p>
+
+      <Link
+        href={`/movies/${id}`}
+        onMouseOver={tooltip}
+        onMouseOut={hideTooltip}
+      >
+        {title}
+      </Link>
     </div>
   );
 }

--- a/styles/movie.module.css
+++ b/styles/movie.module.css
@@ -4,6 +4,7 @@
   gap: 20px;
   cursor: pointer;
   place-items: center;
+  position: relative;
 }
 
 .movie img {
@@ -24,4 +25,17 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.movie p {
+  position: absolute;
+  top: 0;
+  background-color: #2d2d2dbf;
+  color: white;
+  text-align: center;
+  padding: 5px;
+  border-radius: 3px;
+  display: none;
+  overflow: visible;
+  z-index: 10;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,6 @@
       "@styles/*": ["styles/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
## ✨ 완료된 기능
- [x] `a`태그 `hover` 시 툴팁 띄우기
  - `css` `position` 속성과 `onMouseOver`, `onMouseOut`을 이용해 구현
  - [툴팁 구현](https://esthel.notion.site/a-hover-2a09b6356326447880cf32b49a6216bd?pvs=4)에 자세히 기록

- closed #1 

## 📷 완료된 기능 사진
<div align="center">
  <img src="https://github.com/esthel7/next.js/assets/96722691/750ff3cc-d09b-43d2-9a41-7ba7e73073f1">
</div>
